### PR TITLE
Destroying matterjs fails as world is already null

### DIFF
--- a/src/physics/matter-js/MatterPhysics.js
+++ b/src/physics/matter-js/MatterPhysics.js
@@ -326,12 +326,16 @@ var MatterPhysics = new Class({
     {
         var eventEmitter = this.systems.events;
 
-        eventEmitter.off(SceneEvents.UPDATE, this.world.update, this.world);
-        eventEmitter.off(SceneEvents.POST_UPDATE, this.world.postUpdate, this.world);
+        if(this.world !== null) { 
+          eventEmitter.off(SceneEvents.UPDATE, this.world.update, this.world);
+          eventEmitter.off(SceneEvents.POST_UPDATE, this.world.postUpdate, this.world);
+        }
         eventEmitter.off(SceneEvents.SHUTDOWN, this.shutdown, this);
 
         this.add.destroy();
-        this.world.destroy();
+        if(this.world !== null) {
+          this.world.destroy();
+        }
 
         this.add = null;
         this.world = null;


### PR DESCRIPTION
See https://jsfiddle.net/gm750vo4/1/

This PR
* Fixes a bug

Describe the changes below:
Added check if world exists in MatterPhysics.shutdown
